### PR TITLE
Fix test bugs in rate_limit module

### DIFF
--- a/example.pgdog.toml
+++ b/example.pgdog.toml
@@ -250,8 +250,8 @@ auth_type = "scram"
 # Prevents brute-force authentication attacks by limiting the number
 # of authentication attempts from a single IP address.
 #
-# Default: 10
-auth_rate_limit = 10
+# Default: unlimited (disabled)
+# auth_rate_limit = 10
 
 # Disable cross-shard queries.
 #


### PR DESCRIPTION
- Extract test_unlimited_mode_allows_all from nested function so it runs
- Fix test_reload to set known limit instead of assuming config default
- Update example.pgdog.toml to document correct default (unlimited)